### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -57,13 +57,12 @@ async def exception_handler(request: Request, error: Exception) -> JSONResponse:
     :param error: Exception raised by application
     :return: Response to client
     """
-    log_.exception(error)
+    log_.exception(traceback.format_exc())
     content = {
         "message": "Something went wrong.",
         "url": str(request.url),
         "sender": str(request.client),
         "exception_args": [repr(x) for x in error.args],
-        "trace": traceback.format_exc().split("\n"),
     }
     return JSONResponse(
         status_code=500,


### PR DESCRIPTION
Potential fix for [https://github.com/NielsDegrande/api/security/code-scanning/3](https://github.com/NielsDegrande/api/security/code-scanning/3)

To fix the problem, we need to modify the exception handler to log the stack trace on the server and return a generic error message to the user. This ensures that sensitive information is not exposed to the end user while still allowing developers to access the stack trace for debugging purposes.

- Remove the stack trace from the JSON response content.
- Log the stack trace on the server using the existing logging mechanism.
- Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
