### PR TITLE
Switch to SQLModel

### DIFF
--- a/api/common/orm/base.py
+++ b/api/common/orm/base.py
@@ -1,5 +1,6 @@
 """Base ORM."""
 
-from sqlalchemy.orm import declarative_base
+from sqlmodel import SQLModel
 
-Base = declarative_base()
+# Use SQLModel as the declarative base for all ORM models.
+Base = SQLModel

--- a/api/common/orm/users.py
+++ b/api/common/orm/users.py
@@ -2,12 +2,7 @@
 
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-    relationship,
-)
+from sqlmodel import Field, Relationship
 
 from api.common.orm.base import Base
 from api.config import config
@@ -16,24 +11,16 @@ if TYPE_CHECKING:
     from api.common.orm.feedbacks import Feedbacks
 
 
-class Users(Base):
+class Users(Base, table=True):
     """ORM class to represent a user."""
 
     __tablename__ = "users"
     __table_args__: ClassVar = {"schema": config.common.database_schema}
 
-    user_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-        nullable=False,
-    )
-    username: Mapped[str] = mapped_column(nullable=False)
-    password_hash: Mapped[str] = mapped_column(nullable=False)
-    roles: Mapped[str] = mapped_column(nullable=True)
+    user_id: int | None = Field(default=None, primary_key=True)
+    username: str
+    password_hash: str
+    roles: str | None = None
 
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    feedbacks: Mapped["Feedbacks"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Feedbacks",
-        back_populates="user",
-    )
+    # Relationship to feedback entries for this user.
+    feedbacks: list["Feedbacks"] = Relationship(back_populates="user")

--- a/api/sample/orm/access_rights.py
+++ b/api/sample/orm/access_rights.py
@@ -2,13 +2,8 @@
 
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import ForeignKey
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-    relationship,
-)
+from sqlalchemy import Column, ForeignKey
+from sqlmodel import Field, Relationship
 
 from api.common.orm.base import Base
 from api.config import config
@@ -19,42 +14,35 @@ if TYPE_CHECKING:
     from api.sample.orm.products import Products
 
 
-class ProductAccessRights(Base):
+class ProductAccessRights(Base, table=True):
     """ORM class to represent product access rights."""
 
     __tablename__ = "access_rights"
     __table_args__: ClassVar = {"schema": config.sample.database_schema}
 
-    access_right_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-    )
-    access_level: Mapped[AccessLevels] = mapped_column(nullable=False)
+    access_right_id: int | None = Field(default=None, primary_key=True)
+    access_level: AccessLevels
 
-    product_id: Mapped[int] = mapped_column(
-        ForeignKey(
-            f"{config.sample.database_schema}.products.product_id",
-            name="fk_products_access_rights_product_id",
-            ondelete="CASCADE",
+    product_id: int = Field(
+        foreign_key=f"{config.sample.database_schema}.products.product_id",
+        sa_column=Column(
+            ForeignKey(
+                f"{config.sample.database_schema}.products.product_id",
+                name="fk_products_access_rights_product_id",
+                ondelete="CASCADE",
+            ),
         ),
-        nullable=False,
     )
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    concept: Mapped["Products"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Products",
-    )
+    concept: "Products" = Relationship()
 
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey(
-            f"{config.common.database_schema}.users.user_id",
-            name="fk_users_access_rights_user_id",
-            ondelete="CASCADE",
+    user_id: int = Field(
+        foreign_key=f"{config.common.database_schema}.users.user_id",
+        sa_column=Column(
+            ForeignKey(
+                f"{config.common.database_schema}.users.user_id",
+                name="fk_users_access_rights_user_id",
+                ondelete="CASCADE",
+            ),
         ),
-        nullable=False,
     )
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    user: Mapped["Users"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Users",
-    )
+    user: "Users" = Relationship()

--- a/api/sample/orm/products.py
+++ b/api/sample/orm/products.py
@@ -2,26 +2,19 @@
 
 from typing import ClassVar
 
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-)
+from sqlmodel import Field
 
 from api.common.orm.base import Base
 from api.config import config
 
 
-class Products(Base):
+class Products(Base, table=True):
     """ORM class to represent feedback."""
 
     __tablename__ = "products"
     __table_args__: ClassVar = {"schema": config.sample.database_schema}
 
-    product_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-    )
-    product_name: Mapped[str] = mapped_column(nullable=False)
-    color: Mapped[str] = mapped_column(nullable=False)
-    price: Mapped[float] = mapped_column(nullable=False)
+    product_id: int | None = Field(default=None, primary_key=True)
+    product_name: str
+    color: str
+    price: float

--- a/api/utils/database.py
+++ b/api/utils/database.py
@@ -14,8 +14,8 @@ from sqlalchemy.pool import (
     AsyncAdaptedQueuePool,
     NullPool,
 )
+from sqlmodel import SQLModel
 
-from api.common.orm.base import Base
 from api.config import config
 
 
@@ -59,7 +59,7 @@ TypeVarBaseModel = TypeVar("TypeVarBaseModel", bound=BaseModel)
 # Pyright warning: Variable not allowed in type expression.
 TypeVarORMModel = TypeVar(
     "TypeVarORMModel",
-    bound=Base,  # pyright: ignore[reportInvalidTypeForm]
+    bound=SQLModel,  # pyright: ignore[reportInvalidTypeForm]
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-box~=7.3",
     "python-dotenv>=1.1.0",
     "pyyaml>=6.0.2",
-    "sqlalchemy[asyncio]>=2.0.40",
+    "sqlmodel>=0.0.16",
     "uvicorn[standard]>=0.34.2",
     "uvloop>=0.21.0",
 ]
@@ -37,7 +37,6 @@ dev = [
     "isort",
     "pre-commit",
     "ruff",
-    "sqlalchemy2-stubs",
     "sqlfluff",
     "types-PyYAML",
     "vulture",


### PR DESCRIPTION
## Summary
- migrate ORM models from SQLAlchemy to SQLModel
- update database utilities for SQLModel
- replace SQLAlchemy dependency with SQLModel

## Testing
- `ruff format` *(all files left unchanged)*
- `ruff check` *(passed)*