### PR TITLE
Switch to SQLModel

### DIFF
--- a/api/common/orm/base.py
+++ b/api/common/orm/base.py
@@ -1,5 +1,6 @@
 """Base ORM."""
 
-from sqlalchemy.orm import declarative_base
+from sqlmodel import SQLModel
 
-Base = declarative_base()
+# Use SQLModel as the declarative base for all ORM models.
+Base = SQLModel

--- a/api/common/orm/feedbacks.py
+++ b/api/common/orm/feedbacks.py
@@ -3,13 +3,8 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import Column, DateTime, ForeignKey
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-    relationship,
-)
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, Relationship
 
 from api.common.orm.base import Base
 from api.config import config
@@ -18,37 +13,28 @@ if TYPE_CHECKING:
     from api.common.orm.users import Users
 
 
-class Feedbacks(Base):
+class Feedbacks(Base, table=True):
     """ORM class to represent feedback."""
 
-    __tablename__ = "feedbacks"
+    __tablename__: ClassVar[str] = "feedbacks"
     __table_args__: ClassVar = {"schema": config.common.database_schema}
 
-    feedback_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-    )
-    url_path: Mapped[str] = mapped_column(nullable=False)
-    feedback_message: Mapped[str] = mapped_column(nullable=False)
-    time_created = Column(
-        "time_created",
-        DateTime(timezone=True),
-        nullable=False,
-        default=lambda: datetime.now(UTC),
+    feedback_id: int | None = Field(default=None, primary_key=True)
+    url_path: str
+    feedback_message: str
+    time_created: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            "time_created",
+            DateTime(timezone=True),
+            nullable=False,
+        ),
     )
 
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey(
-            f"{config.common.database_schema}.users.user_id",
-            ondelete="CASCADE",
-        ),
+    user_id: int = Field(
+        foreign_key=f"{config.common.database_schema}.users.user_id",
         nullable=False,
-        # Put an index on columns you will filter by often.
         index=True,
     )
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    user: Mapped["Users"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Users",
-        back_populates="feedbacks",
-    )
+    # Link back to the user who submitted the feedback.
+    user: "Users" = Relationship(back_populates="feedbacks")

--- a/api/common/orm/users.py
+++ b/api/common/orm/users.py
@@ -2,12 +2,7 @@
 
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-    relationship,
-)
+from sqlmodel import Field, Relationship
 
 from api.common.orm.base import Base
 from api.config import config
@@ -16,24 +11,16 @@ if TYPE_CHECKING:
     from api.common.orm.feedbacks import Feedbacks
 
 
-class Users(Base):
+class Users(Base, table=True):
     """ORM class to represent a user."""
 
-    __tablename__ = "users"
+    __tablename__: ClassVar[str] = "users"
     __table_args__: ClassVar = {"schema": config.common.database_schema}
 
-    user_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-        nullable=False,
-    )
-    username: Mapped[str] = mapped_column(nullable=False)
-    password_hash: Mapped[str] = mapped_column(nullable=False)
-    roles: Mapped[str] = mapped_column(nullable=True)
+    user_id: int | None = Field(default=None, primary_key=True)
+    username: str
+    password_hash: str
+    roles: str | None = None
 
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    feedbacks: Mapped["Feedbacks"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Feedbacks",
-        back_populates="user",
-    )
+    # Relationship to feedback entries for this user.
+    feedbacks: list["Feedbacks"] = Relationship(back_populates="user")

--- a/api/common/repositories/user_repository.py
+++ b/api/common/repositories/user_repository.py
@@ -15,7 +15,7 @@ async def read_user(username: str) -> User:
     :return: Matching user.
     """
     async with AsyncSessionLocal() as session, session.begin():
-        query = select(Users).where(Users.username == username)
+        query = select(Users).where(Users.username == username)  # pyright: ignore[reportArgumentType]
         result = await session.execute(query)
         user = result.scalars().first()
 

--- a/api/sample/orm/access_rights.py
+++ b/api/sample/orm/access_rights.py
@@ -2,13 +2,8 @@
 
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import ForeignKey
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-    relationship,
-)
+from sqlalchemy import Column, ForeignKey
+from sqlmodel import Field, Relationship
 
 from api.common.orm.base import Base
 from api.config import config
@@ -19,42 +14,35 @@ if TYPE_CHECKING:
     from api.sample.orm.products import Products
 
 
-class ProductAccessRights(Base):
+class ProductAccessRights(Base, table=True):
     """ORM class to represent product access rights."""
 
-    __tablename__ = "access_rights"
+    __tablename__: ClassVar[str] = "access_rights"
     __table_args__: ClassVar = {"schema": config.sample.database_schema}
 
-    access_right_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-    )
-    access_level: Mapped[AccessLevels] = mapped_column(nullable=False)
+    access_right_id: int | None = Field(default=None, primary_key=True)
+    access_level: AccessLevels
 
-    product_id: Mapped[int] = mapped_column(
-        ForeignKey(
-            f"{config.sample.database_schema}.products.product_id",
-            name="fk_products_access_rights_product_id",
-            ondelete="CASCADE",
+    product_id: int = Field(
+        foreign_key=f"{config.sample.database_schema}.products.product_id",
+        sa_column=Column(
+            ForeignKey(
+                f"{config.sample.database_schema}.products.product_id",
+                name="fk_products_access_rights_product_id",
+                ondelete="CASCADE",
+            ),
         ),
-        nullable=False,
-    )
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    concept: Mapped["Products"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Products",
-    )
+    )  # pyright: ignore[reportCallIssue]
+    concept: "Products" = Relationship()
 
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey(
-            f"{config.common.database_schema}.users.user_id",
-            name="fk_users_access_rights_user_id",
-            ondelete="CASCADE",
+    user_id: int = Field(
+        foreign_key=f"{config.common.database_schema}.users.user_id",
+        sa_column=Column(
+            ForeignKey(
+                f"{config.common.database_schema}.users.user_id",
+                name="fk_users_access_rights_user_id",
+                ondelete="CASCADE",
+            ),
         ),
-        nullable=False,
-    )
-    # Pyright error: Expression of type "relationship"
-    # cannot be assigned to declared type.
-    user: Mapped["Users"] = relationship(  # pyright: ignore[reportAssignmentType]
-        "Users",
-    )
+    )  # pyright: ignore[reportCallIssue]
+    user: "Users" = Relationship()

--- a/api/sample/orm/products.py
+++ b/api/sample/orm/products.py
@@ -2,26 +2,19 @@
 
 from typing import ClassVar
 
-from sqlalchemy.orm import (
-    Mapped,
-    # Pyright error: "mapped_column" is unknown import symbol.
-    mapped_column,  # pyright: ignore[reportAttributeAccessIssue]
-)
+from sqlmodel import Field
 
 from api.common.orm.base import Base
 from api.config import config
 
 
-class Products(Base):
+class Products(Base, table=True):
     """ORM class to represent feedback."""
 
-    __tablename__ = "products"
+    __tablename__: ClassVar[str] = "products"
     __table_args__: ClassVar = {"schema": config.sample.database_schema}
 
-    product_id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-    )
-    product_name: Mapped[str] = mapped_column(nullable=False)
-    color: Mapped[str] = mapped_column(nullable=False)
-    price: Mapped[float] = mapped_column(nullable=False)
+    product_id: int | None = Field(default=None, primary_key=True)
+    product_name: str
+    color: str
+    price: float

--- a/api/sample/repositories/access_right_repository.py
+++ b/api/sample/repositories/access_right_repository.py
@@ -56,12 +56,12 @@ async def _read_access_right(
     """
     async with AsyncSessionLocal() as session, session.begin():
         query = (
-            select(ProductAccessRights, Users.username)
+            select(ProductAccessRights, Users.username)  # pyright: ignore[reportCallIssue]
             .join(Users)
             .where(
                 and_(
-                    ProductAccessRights.user_id == user_id,
-                    ProductAccessRights.product_id == product_id,
+                    ProductAccessRights.user_id == user_id,  # pyright: ignore[reportArgumentType]
+                    ProductAccessRights.product_id == product_id,  # pyright: ignore[reportArgumentType]
                 ),
             )
         )

--- a/api/sample/repositories/product_repository.py
+++ b/api/sample/repositories/product_repository.py
@@ -38,7 +38,7 @@ async def read_products(user_id: int) -> list[ProductResponse]:
         query = (
             select(Products)
             .join(ProductAccessRights)
-            .where(ProductAccessRights.user_id == user_id)
+            .where(ProductAccessRights.user_id == user_id)  # pyright: ignore[reportArgumentType]
         )
         products = (await session.execute(query)).scalars().all()
         return [orm_to_pydantic(product, ProductResponse) for product in products]
@@ -65,11 +65,11 @@ async def _read_product(
     query = (
         select(Products)
         .join(ProductAccessRights)
-        .where(ProductAccessRights.user_id == user_id)
-        .where(Products.product_id == product_id)
+        .where(ProductAccessRights.user_id == user_id)  # pyright: ignore[reportArgumentType]
+        .where(Products.product_id == product_id)  # pyright: ignore[reportArgumentType]
     )
     if access_levels:
-        query = query.where(ProductAccessRights.access_level.in_(access_levels))
+        query = query.where(ProductAccessRights.access_level.in_(access_levels))  # pyright: ignore[reportAttributeAccessIssue]
     if with_for_update:
         query = query.with_for_update()
     result = await session.execute(query)

--- a/api/utils/database.py
+++ b/api/utils/database.py
@@ -14,8 +14,8 @@ from sqlalchemy.pool import (
     AsyncAdaptedQueuePool,
     NullPool,
 )
+from sqlmodel import SQLModel
 
-from api.common.orm.base import Base
 from api.config import config
 
 
@@ -59,7 +59,7 @@ TypeVarBaseModel = TypeVar("TypeVarBaseModel", bound=BaseModel)
 # Pyright warning: Variable not allowed in type expression.
 TypeVarORMModel = TypeVar(
     "TypeVarORMModel",
-    bound=Base,  # pyright: ignore[reportInvalidTypeForm]
+    bound=SQLModel,  # pyright: ignore[reportInvalidTypeForm]
 )
 
 

--- a/db_migrations/env.py
+++ b/db_migrations/env.py
@@ -4,7 +4,7 @@ import asyncio
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy.ext.asyncio import AsyncConnection
+from sqlalchemy.engine import Connection
 
 from api.common.orm.base import Base
 from api.utils.database import create_connection_string, engine
@@ -48,15 +48,13 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def _run_sync_migration(connection: AsyncConnection) -> None:
+def _run_sync_migration(connection: Connection) -> None:
     """Run migration synchronously.
 
     :param connection: Connection to use for the migration.
     """
     context.configure(
-        # Pyright error: Argument of type "AsyncConnection" cannot be assigned
-        # to parameter of type "Connection".
-        connection=connection,  # type: ignore[reportGeneralTypeIssues]
+        connection=connection,
         target_metadata=target_metadata,
         # Required as we are using a non-default schema.
         include_schemas=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-box~=7.3",
     "python-dotenv>=1.1.0",
     "pyyaml>=6.0.2",
-    "sqlalchemy[asyncio]>=2.0.40",
+    "sqlmodel>=0.0.16",
     "uvicorn[standard]>=0.34.2",
     "uvloop>=0.21.0",
 ]
@@ -37,7 +37,6 @@ dev = [
     "isort",
     "pre-commit",
     "ruff",
-    "sqlalchemy2-stubs",
     "sqlfluff",
     "types-PyYAML",
     "vulture",


### PR DESCRIPTION
## Summary
- migrate ORM models from SQLAlchemy to SQLModel
- update database utilities for SQLModel
- replace SQLAlchemy dependency with SQLModel
- fix SQLModel migration issues

## Testing
- `ruff format api/common/orm/feedbacks.py api/common/orm/users.py api/sample/orm/access_rights.py api/sample/orm/products.py api/common/repositories/user_repository.py api/sample/repositories/product_repository.py api/sample/repositories/access_right_repository.py db_migrations/env.py`
- `ruff check api/common/orm/feedbacks.py api/common/orm/users.py api/sample/orm/access_rights.py api/sample/orm/products.py api/common/repositories/user_repository.py api/sample/repositories/product_repository.py api/sample/repositories/access_right_repository.py db_migrations/env.py`
- `pyright api/common/orm/feedbacks.py api/common/orm/users.py api/sample/orm/access_rights.py api/sample/orm/products.py api/common/repositories/user_repository.py api/sample/repositories/product_repository.py api/sample/repositories/access_right_repository.py db_migrations/env.py` *(fails: missing imports)*